### PR TITLE
Update arangors to 0.5, add and re-export uclient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2d2_arangors"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Rafael Aggeler <r.aggeler@gmx.net>"]
 license = "MIT"
 description = "ArangoDB support for the r2d2 connection pool"
@@ -8,5 +8,6 @@ repository = "https://github.com/inzanez/r2d2-arangors"
 edition = "2018"
 
 [dependencies]
-arangors = { version = ">=0.4.3", features = ["reqwest_blocking"], default-features = false }
-r2d2 = "0.8.8"
+arangors = { version = "0.5", features = ["reqwest_blocking"], default-features = false }
+uclient = { version = "0.1", features = ["blocking_reqwest"], default-features = false }
+r2d2 = "0.8.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,10 @@
 #![crate_name = "r2d2_arangors"]
 
 pub mod pool;
-use pool::ArangoDBConnectionManager;
 
 #[cfg(test)]
 mod tests {
     use crate::pool::ArangoDBConnectionManager;
-    use arangors::Connection;
     use std::time::Duration;
     #[test]
     #[should_panic]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,7 +1,8 @@
 use arangors::error::ClientError;
 use r2d2;
-use std::fmt;
 use std::result::Result;
+
+pub use uclient::ClientExt;
 
 #[derive(Clone, Debug)]
 pub struct ArangoDBConnectionManager {
@@ -40,10 +41,10 @@ impl r2d2::ManageConnection for ArangoDBConnectionManager {
     }
 
     fn is_valid(&self, conn: &mut arangors::Connection) -> Result<(), ClientError> {
-        arangors::connection::GenericConnection::<arangors::client::reqwest::ReqwestClient>::validate_server(&conn.url().to_string())
+        arangors::connection::GenericConnection::<uclient::reqwest::ReqwestClient>::validate_server(&conn.url().to_string())
     }
 
     fn has_broken(&self, conn: &mut arangors::Connection) -> bool {
-        arangors::connection::GenericConnection::<arangors::client::reqwest::ReqwestClient>::validate_server(&conn.url().to_string()).is_err()
+        arangors::connection::GenericConnection::<uclient::reqwest::ReqwestClient>::validate_server(&conn.url().to_string()).is_err()
     }
 }


### PR DESCRIPTION
Uclient is now needed, because arangors uses it as a unified client
interface, but does not re-export it.